### PR TITLE
Allow sending session parameters per body parameter for compatibility reasons

### DIFF
--- a/src/PluginSession.php
+++ b/src/PluginSession.php
@@ -76,9 +76,9 @@ class PluginSession extends SSOData
 			session_set_save_handler($sessionHandler, true);
 
 
-		$pid = isset($_GET[self::QUERY_PARAM_PID]) ? $_GET[self::QUERY_PARAM_PID] : null;
-		$jwt = isset($_GET[self::QUERY_PARAM_JWT]) ? $_GET[self::QUERY_PARAM_JWT] : null;
-		$sid = isset($_GET[self::QUERY_PARAM_SID]) ? $_GET[self::QUERY_PARAM_SID] : null;
+		$pid = isset($_REQUEST[self::QUERY_PARAM_PID]) ? $_REQUEST[self::QUERY_PARAM_PID] : null;
+		$jwt = isset($_REQUEST[self::QUERY_PARAM_JWT]) ? $_REQUEST[self::QUERY_PARAM_JWT] : null;
+		$sid = isset($_REQUEST[self::QUERY_PARAM_SID]) ? $_REQUEST[self::QUERY_PARAM_SID] : null;
 
 		// lets hint to bad class usage, as these cases should never happen.
 		if($pid && $jwt) {

--- a/test/PluginSessionTest.php
+++ b/test/PluginSessionTest.php
@@ -61,8 +61,8 @@ class PluginSessionTest extends TestCase
 	 */
 	private function setupEnvironment($queryParamPid = null, $queryParamJwt = null, $clearSession = true) {
 
-		$_GET[PluginSession::QUERY_PARAM_PID] = $queryParamPid;
-		$_GET[PluginSession::QUERY_PARAM_JWT] = $queryParamJwt;
+		$_REQUEST[PluginSession::QUERY_PARAM_PID] = $queryParamPid;
+		$_REQUEST[PluginSession::QUERY_PARAM_JWT] = $queryParamJwt;
 
 		if($clearSession) {
 			session_write_close();


### PR DESCRIPTION
This allows to send specific sessions parameters as body parameter. This is for compatibility reasons as there some legacy plugins using this. 

"An associative array that by default contains the contents of $_GET, $_POST and $_COOKIE."
https://www.php.net/manual/en/reserved.variables.request.php