### PR TITLE
CI-1108: Add Dependabot cooldown to mitigate supply-chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "weekly"
       time: "08:00"
       timezone: "Europe/Berlin"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
 
   - package-ecosystem: "composer"
@@ -15,6 +17,8 @@ updates:
       interval: "weekly"
       time: "08:00"
       timezone: "Europe/Berlin"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       composer-prod-updates:


### PR DESCRIPTION
## Summary

- Adds a 7-day cooldown period to Dependabot configuration
- This helps protect against supply-chain attacks by ensuring new package versions have time to be vetted by the community before adoption

## Jira

[CI-1108](https://mitarbeiterapp.atlassian.net/browse/CI-1108)

---
*This PR was created with [opencode](https://opencode.ai) using Claude Sonnet 4.5*

[CI-1108]: https://mitarbeiterapp.atlassian.net/browse/CI-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ