### PR TITLE
chore: assign ownership to Product · Actions team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @Staffbase/product-central-tech
+* @Staffbase/product-actions

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,5 +7,6 @@ metadata:
   tags:
     - php
 spec:
+  owner: group:default/product-actions
   type: library
   lifecycle: production


### PR DESCRIPTION
Reassigns ownership of this component to the **Product · Actions** team (`product-actions`).

Changes:
- `catalog-info.yaml`: `spec.owner` → `group:default/product-actions` (and `github.com/team-slug` annotation where present).
- `.github/CODEOWNERS`: default (`*`) owner → `@Staffbase/product-actions`.

Infrastructure `Resource` entries (e.g. S3 buckets owned by `infra-email`) are intentionally left unchanged.
